### PR TITLE
Refactor the svg compiling into a factory

### DIFF
--- a/src/sd.js
+++ b/src/sd.js
@@ -66,7 +66,7 @@
      * A reusuable service that other custom directives 
      * can use for rendering custom SVG templates
      */
-    angular.module('sd').factory('svgBuilder', function( $compile ) {
+    angular.module('sd').factory('svgCompile', function( $compile ) {
         
         var xmlSerializer = new XMLSerializer();
 
@@ -130,7 +130,7 @@
      * TODO implement full spec: http://www.w3.org/TR/xinclude/
      * TODO polyfill for XPathEvaluator
      */
-    angular.module('sd').directive('sdXinclude', function($http, $templateCache, svgBuilder ) {
+    angular.module('sd').directive('sdXinclude', function($http, $templateCache, svgCompile ) {
 
         
         return {
@@ -145,7 +145,7 @@
                     $http.get(href, {
                         cache: $templateCache
                     }).success(function(response) {
-                        svgBuilder.build( response, iElement, scope, xpointer  );
+                        svgCompile.build( response, iElement, scope, xpointer  );
                     }).error(function(error) {
 
                     });

--- a/src/sd.js
+++ b/src/sd.js
@@ -63,13 +63,76 @@
     }
 
     /**
+     * A reusuable service that other custom directives 
+     * can use for rendering custom SVG templates
+     */
+    angular.module('sd').factory('svgBuilder', function( $compile ) {
+        
+        var xmlSerializer = new XMLSerializer();
+
+        /**
+         * Pass in the template string, element from angular
+         * directive, scope and xpointer and the template
+         * will be rendered on the provided element
+         */
+        function buildSvg( template, iElement, scope, xpointer  ){
+            var element = iElement[0];
+            var parentNode = element.parentNode;
+            var tpl = '<svg>' + template + '</svg>',
+                wrapper = document.createElement('div'),
+                xPathWrapper = document.createElement('div'),
+                frag = document.createDocumentFragment(),
+                xPathResult,
+                nodes = [],
+                xml = '',
+                node;
+            wrapper.insertAdjacentHTML('afterBegin', tpl);
+
+            if (xpointer) {
+                xPathWrapper.insertAdjacentHTML('afterBegin', '<svg></svg>');
+                xPathResult = document.evaluate(xpointer, wrapper, null, XPathResult.ANY_TYPE, null);
+                while (xPathResult && (node = xPathResult.iterateNext())) {
+                    nodes.push(node);
+                }
+                angular.forEach(nodes, function(node) {
+                    xml += xmlSerializer.serializeToString(node, 'text/xml');
+                });
+                xPathWrapper.insertAdjacentHTML('afterBegin', '<svg>' + xml + '</svg>');
+                for (var j = 0, childNode; childNode = xPathWrapper.firstChild.childNodes[j++];) {
+                    frag.appendChild(childNode);
+                }
+            } else {
+                frag.appendChild(wrapper.firstChild.firstChild);
+            }
+
+            element.appendChild(frag);
+
+            $compile(iElement.contents())(scope, function(clonedElement, scope) {
+                var frag = document.createDocumentFragment();
+                for (var i = 0, ii = clonedElement.length; i < ii; i++) {
+                    frag.appendChild(clonedElement[i]);
+                }
+                parentNode.replaceChild(frag, element);
+            });
+
+            wrapper = null;
+            xPathWrapper = null;
+        }
+
+        return {
+            build : buildSvg
+        }
+      
+    });
+
+    /**
      * xinclude directive.
      * TODO implement full spec: http://www.w3.org/TR/xinclude/
      * TODO polyfill for XPathEvaluator
      */
-    angular.module('sd').directive('sdXinclude', function($http, $compile, $templateCache) {
+    angular.module('sd').directive('sdXinclude', function($http, $templateCache, svgBuilder ) {
 
-        var xmlSerializer = new XMLSerializer();
+        
         return {
             restrict: 'E',
             compile: function compile(tElement, tAttrs, transclude) {
@@ -82,45 +145,7 @@
                     $http.get(href, {
                         cache: $templateCache
                     }).success(function(response) {
-
-                        var tpl = '<svg>' + response + '</svg>',
-                            wrapper = document.createElement('div'),
-                            xPathWrapper = document.createElement('div'),
-                            frag = document.createDocumentFragment(),
-                            xPathResult,
-                            nodes = [],
-                            xml = '',
-                            node;
-                        wrapper.insertAdjacentHTML('afterBegin', tpl);
-
-                        if (xpointer) {
-                            xPathWrapper.insertAdjacentHTML('afterBegin', '<svg></svg>');
-                            xPathResult = document.evaluate(xpointer, wrapper, null, XPathResult.ANY_TYPE, null);
-                            while (xPathResult && (node = xPathResult.iterateNext())) {
-                                nodes.push(node);
-                            }
-                            angular.forEach(nodes, function(node) {
-                                xml += xmlSerializer.serializeToString(node, 'text/xml');
-                            });
-                            xPathWrapper.insertAdjacentHTML('afterBegin', '<svg>' + xml + '</svg>');
-                            for (var j = 0, childNode; childNode = xPathWrapper.firstChild.childNodes[j++];) {
-                                frag.appendChild(childNode);
-                            }
-                        } else {
-                            frag.appendChild(wrapper.firstChild.firstChild);
-                        }
-                        element.appendChild(frag);
-
-                        $compile(iElement.contents())(scope, function(clonedElement, scope) {
-                            var frag = document.createDocumentFragment();
-                            for (var i = 0, ii = clonedElement.length; i < ii; i++) {
-                                frag.appendChild(clonedElement[i]);
-                            }
-                            parentNode.replaceChild(frag, element);
-                        });
-
-                        wrapper = null;
-                        xPathWrapper = null;
+                        svgBuilder.build( response, iElement, scope, xpointer  );
                     }).error(function(error) {
 
                     });


### PR DESCRIPTION
The compiling functionality could ideally be used by other custom SVG directives. I separated the functionality that handles compiling of an element into a factory that other directives can inject for reuse.
